### PR TITLE
Enable typing for external users

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         "Programming Language :: Python",
     ],
     packages=find_packages(exclude=["tests", "example"]),
+    package_data={'hasql': ['py.typed']},
     install_requires=[],
     extras_require={
         "aiopg": [


### PR DESCRIPTION
Hello, we want to use the library, but the types are not checked, although they are in the code.
Seems need add `py.typed` marker

[Enable typing docs](https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports)