### PR TITLE
fix: Add handling CancelledError when releasing a system connection

### DIFF
--- a/hasql/base.py
+++ b/hasql/base.py
@@ -524,6 +524,15 @@ class BasePoolManager(ABC):
                             censored_dsn,
                             exc_info=True,
                         )
+                    except asyncio.CancelledError as cancelled_error:
+                        if self._closing:
+                            raise cancelled_error from None
+                        logger.warning(
+                            "Release connection to pool with "
+                            "Cancelled error for dsn=%r",
+                            censored_dsn,
+                            exc_info=True,
+                        )
                     sys_connection = None
                 await self._notify_about_pool_has_checked(dsn)
 


### PR DESCRIPTION
to prevent check_pool_task from crashing

refs: https://github.com/aiokitchen/hasql/issues/13