### PR TITLE
Added COMMIT after detect role of pool

### DIFF
--- a/hasql/asyncsqlalchemy.py
+++ b/hasql/asyncsqlalchemy.py
@@ -28,9 +28,11 @@ class PoolManager(BasePoolManager):
         await connection.close()
 
     async def _is_master(self, connection: AsyncConnection):
-        return await connection.scalar(
+        result = await connection.scalar(
             sa.text("SHOW transaction_read_only"),
         ) == "off"
+        await connection.execute(sa.text('COMMIT'))
+        return result
 
     async def _pool_factory(self, dsn: Dsn):
         # TODO: Add support of psycopg3 after release of sqlalchemy 2.0

--- a/hasql/base.py
+++ b/hasql/base.py
@@ -4,17 +4,8 @@ from abc import ABC, abstractmethod
 from collections import defaultdict
 from itertools import chain
 from types import MappingProxyType
-from typing import (
-    Any,
-    AsyncContextManager,
-    DefaultDict,
-    Dict,
-    List,
-    Optional,
-    Sequence,
-    Set,
-    Union,
-)
+from typing import (Any, AsyncContextManager, DefaultDict, Dict, List,
+                    Optional, Sequence, Set, Union)
 
 from .metrics import CalculateMetrics, DriverMetrics, Metrics
 from .utils import Dsn, Stopwatch, split_dsn
@@ -517,7 +508,7 @@ class BasePoolManager(ABC):
                 if sys_connection is not None:
                     try:
                         await self.release_to_pool(sys_connection, pool)
-                    except Exception:
+                    except (Exception, asyncio.CancelledError):
                         logger.warning(
                             "Release connection to pool with "
                             "exception for dsn=%r",


### PR DESCRIPTION
We have two problem with system connection:
1. The age of the system transaction is growing very much
![image](https://github.com/user-attachments/assets/2f0537f9-539b-4597-a276-9dffcb247763)
2. After promote replica to master the result of "SHOW transaction_read_only" command always "on" because the transaction started before the promote. Promote to master does not break transaction/connection.

I added COMMIT to solve them both.