### PR TITLE
fix(pool): share acquire timeout budget across connection phases

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,44 +7,44 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 **Testing:**
 ```bash
 # Run all tests
-pytest -vv --cov=hasql --cov-report=term-missing --doctest-modules --aiomisc-test-timeout=30 tests
+uv run pytest -vv --cov=hasql --cov-report=term-missing --doctest-modules --aiomisc-test-timeout=30 tests
 
 # Run specific test file
-pytest -vv tests/test_utils.py
+uv run pytest -vv tests/test_utils.py
 
 # Run specific test
-pytest -vv tests/test_utils.py::test_parse_connection_string_basic
+uv run pytest -vv tests/test_utils.py::test_parse_connection_string_basic
 
 # Run tests with specific pattern
-pytest -vv tests/test_utils.py -k "connection_string"
+uv run pytest -vv tests/test_utils.py -k "connection_string"
 
 # Run tests using tox (preferred)
-tox -e py310 # Python 3.10
-tox -e py311 # Python 3.11
+uv run tox -e py310 # Python 3.10
+uv run tox -e py311 # Python 3.11
 ```
 
 **Linting and Type Checking:**
 ```bash
 # Lint code
-pylama -o pylama.ini hasql tests
+uv run ruff check hasql tests
 
 # Type checking
-mypy --install-types --non-interactive hasql tests
+uv run mypy --install-types --non-interactive hasql tests
 
 # Using tox (preferred)
-tox -e lint
-tox -e mypy
+uv run tox -e lint
+uv run tox -e mypy
 ```
 
 **Package Installation:**
 ```bash
 # Install development dependencies
-pip install -e ".[develop]"
+uv sync --group develop
 
-# Install specific extras
-pip install -e ".[aiopg]"      # aiopg support
-pip install -e ".[asyncpg]"    # asyncpg support
-pip install -e ".[psycopg]"    # psycopg3 support
+# Install specific driver groups
+uv sync --group aiopg       # aiopg support
+uv sync --group asyncpg     # asyncpg support
+uv sync --group psycopg     # psycopg3 support
 ```
 
 ## Architecture Overview
@@ -101,7 +101,7 @@ pip install -e ".[psycopg]"    # psycopg3 support
 
 ## Important Notes
 
-- The codebase uses Python 3.8+ with async/await throughout
+- The codebase uses Python 3.10+ with async/await throughout
 - All pool managers extend the abstract `BasePoolManager` class
 - Connection strings support both single and multi-host PostgreSQL URLs
 - Background health checking runs every `refresh_delay` seconds (default: 1s)

--- a/README.rst
+++ b/README.rst
@@ -211,6 +211,10 @@ For ``psycopg3``
 ~~~~~~~~~~~~~~~~
 
 **psycopg3** must be installed as a requirement (package name is `psycopg`)
+Configure queue limits explicitly with
+``pool_factory_kwargs={"max_waiting": ...}`` if you want
+``psycopg_pool.TooManyRequests`` on pool saturation. Otherwise the driver
+default queue behavior is used.
 
 .. code-block:: python
 
@@ -330,7 +334,7 @@ Overview
           between host polls. 1 sec by default.
 
         * ``refresh_timeout: Union[int, float]`` - Timeout (in seconds) for
-          trying to connect and get the host role. 1 sec by default.
+          trying to connect and get the host role. 30 sec by default.
 
         * ``fallback_master: bool`` - Use connections from master if replicas
           are missing. False by default.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "2"
 services:
   postgres:
     restart: always
-    image: mdillon/postgis:11-alpine
+    image: postgres:18-alpine
     expose:
       - 5432
     environment:

--- a/docs/timeouts.md
+++ b/docs/timeouts.md
@@ -26,7 +26,7 @@ pool_manager.acquire_master(timeout=5.0)
 pool_manager.acquire_replica(timeout=5.0)
 ```
 
-Setting `timeout=None` means no timeout (wait indefinitely).
+Setting `timeout=None` (the default) uses the manager-level `acquire_timeout`.
 
 ## Per-driver behavior
 
@@ -43,6 +43,10 @@ using the most appropriate mechanism:
 `_prepare_acquire_kwargs` sets `timeout=<remaining>`, which is passed to
 `pool.getconn(timeout=...)`. psycopg3 raises `psycopg_pool.PoolTimeout`
 natively.
+
+> **Breaking (0.9.0):** Previous versions forced `max_waiting=-1` (unlimited
+> queue) on psycopg3 pools. This override has been removed. If you relied on
+> unlimited waiting, pass `pool_factory_kwargs={"max_waiting": -1}` explicitly.
 
 ### aiopg / aiopg_sa
 

--- a/docs/timeouts.md
+++ b/docs/timeouts.md
@@ -1,0 +1,86 @@
+# Timeout handling in hasql
+
+## Overview
+
+hasql uses a **timeout budget** approach. A single `acquire_timeout` value
+(set per-manager or per-call) is shared across two phases:
+
+1. **Pool selection** — waiting for a healthy pool via the balancer.
+2. **Connection acquisition** — getting a connection from the selected pool.
+
+The remaining budget after pool selection is forwarded to the driver adapter,
+which enforces it using the driver's native mechanism.
+
+## Manager-level timeout
+
+```python
+PoolManager(dsn, acquire_timeout=2.0, ...)
+```
+
+`acquire_timeout` (default `1.0` s) is the total time budget for both phases.
+It can be overridden per call:
+
+```python
+pool_manager.acquire(timeout=5.0)
+pool_manager.acquire_master(timeout=5.0)
+pool_manager.acquire_replica(timeout=5.0)
+```
+
+Setting `timeout=None` means no timeout (wait indefinitely).
+
+## Per-driver behavior
+
+Each driver adapter receives the remaining timeout budget and enforces it
+using the most appropriate mechanism:
+
+### asyncpg
+
+`_prepare_acquire_kwargs` sets `timeout=<remaining>`, which is passed to
+`pool.acquire(timeout=...)`. asyncpg raises `asyncio.TimeoutError` natively.
+
+### psycopg3
+
+`_prepare_acquire_kwargs` sets `timeout=<remaining>`, which is passed to
+`pool.getconn(timeout=...)`. psycopg3 raises `psycopg_pool.PoolTimeout`
+natively.
+
+### aiopg / aiopg_sa
+
+aiopg's `pool.acquire()` does not accept a timeout parameter. hasql wraps
+the acquire call with `asyncio.wait_for(timeout=<remaining>)` inside the
+driver adapter. Raises `asyncio.TimeoutError` on timeout.
+
+### SQLAlchemy async (asyncsqlalchemy)
+
+`pool.connect()` does not accept a timeout parameter. hasql wraps
+the connect call with `asyncio.wait_for(timeout=<remaining>)` inside the
+driver adapter. Raises `asyncio.TimeoutError` on timeout.
+
+## Background health-check timeouts
+
+These are separate from the acquire timeout:
+
+| Parameter         | Default | Purpose                                       |
+|-------------------|---------|-----------------------------------------------|
+| `refresh_delay`   | 1 s     | Interval between health checks                |
+| `refresh_timeout` | 30 s    | Timeout for a single health-check iteration   |
+
+Health checks acquire a system connection and run
+`SHOW transaction_read_only`. If a check exceeds `refresh_timeout`,
+the pool is removed from the available set until the next successful check.
+
+## Timeout flow diagram
+
+```
+acquire(timeout=T)
+  |
+  +-- deadline = now + T
+  |
+  +-- _get_pool(deadline)                   [pool selection, uses remaining budget]
+  |     waits up to (deadline - now)
+  |
+  +-- _acquire_kwargs(deadline)             [computes remaining = deadline - now]
+  |
+  +-- driver.acquire_from_pool(timeout=remaining)
+        each driver enforces timeout using its own mechanism
+```

--- a/hasql/__init__.py
+++ b/hasql/__init__.py
@@ -1,4 +1,4 @@
-__version_info__ = (0, 8, 2)
+__version_info__ = (0, 8, 3)
 __version__ = ".".join(map(str, __version_info__))
 
 package_info = (

--- a/hasql/__init__.py
+++ b/hasql/__init__.py
@@ -1,4 +1,4 @@
-__version_info__ = (0, 8, 3)
+__version_info__ = (0, 9, 0)
 __version__ = ".".join(map(str, __version_info__))
 
 package_info = (

--- a/hasql/aiopg.py
+++ b/hasql/aiopg.py
@@ -11,6 +11,8 @@ from hasql.utils import Dsn
 class PoolManager(BasePoolManager):
     pools: Sequence[aiopg.Pool]
 
+    # TODO: _timeout is a smuggled kwarg key — consider returning a
+    #  (kwargs, timeout) tuple from _prepare_acquire_kwargs instead.
     def _prepare_acquire_kwargs(
         self,
         kwargs: dict,

--- a/hasql/aiopg.py
+++ b/hasql/aiopg.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Optional, Sequence
+from typing import Sequence
 
 import aiopg
 
@@ -14,7 +14,7 @@ class PoolManager(BasePoolManager):
     def _prepare_acquire_kwargs(
         self,
         kwargs: dict,
-        timeout: Optional[float],
+        timeout: float,
     ) -> dict:
         prepared_kwargs = super()._prepare_acquire_kwargs(kwargs, timeout)
         prepared_kwargs["_timeout"] = timeout

--- a/hasql/aiopg.py
+++ b/hasql/aiopg.py
@@ -1,9 +1,9 @@
 import asyncio
-from typing import Sequence
+from typing import Optional, Sequence
 
 import aiopg
 
-from hasql.base import BasePoolManager
+from hasql.base import BasePoolManager, TimeoutAcquireContext
 from hasql.metrics import DriverMetrics
 from hasql.utils import Dsn
 
@@ -11,11 +11,24 @@ from hasql.utils import Dsn
 class PoolManager(BasePoolManager):
     pools: Sequence[aiopg.Pool]
 
+    def _prepare_acquire_kwargs(
+        self,
+        kwargs: dict,
+        timeout: Optional[float],
+    ) -> dict:
+        prepared_kwargs = super()._prepare_acquire_kwargs(kwargs, timeout)
+        prepared_kwargs["_timeout"] = timeout
+        return prepared_kwargs
+
     def get_pool_freesize(self, pool):
         return pool.freesize
 
     def acquire_from_pool(self, pool, **kwargs):
-        return pool.acquire(**kwargs)
+        timeout = kwargs.pop("_timeout", None)
+        ctx = pool.acquire(**kwargs)
+        if timeout is not None:
+            return TimeoutAcquireContext(ctx, timeout)
+        return ctx
 
     async def release_to_pool(self, connection, pool, **kwargs):
         return await pool.release(connection, **kwargs)

--- a/hasql/asyncpg.py
+++ b/hasql/asyncpg.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import ClassVar, Dict, Sequence
+from typing import ClassVar, Dict, Optional, Sequence
 
 import asyncpg  # type: ignore
 from packaging.version import parse as parse_version
@@ -12,6 +12,15 @@ from hasql.utils import Dsn
 class PoolManager(BasePoolManager):
     pools: Sequence[asyncpg.Pool]
     cached_hosts: ClassVar[Dict[int, str]] = {}
+
+    def _prepare_acquire_kwargs(
+        self,
+        kwargs: dict,
+        timeout: Optional[float],
+    ) -> dict:
+        prepared_kwargs = super()._prepare_acquire_kwargs(kwargs, timeout)
+        prepared_kwargs["timeout"] = timeout
+        return prepared_kwargs
 
     def get_pool_freesize(self, pool):
         return pool._queue.qsize()

--- a/hasql/asyncpg.py
+++ b/hasql/asyncpg.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import ClassVar, Dict, Optional, Sequence
+from typing import ClassVar, Dict, Sequence
 
 import asyncpg  # type: ignore
 from packaging.version import parse as parse_version
@@ -16,7 +16,7 @@ class PoolManager(BasePoolManager):
     def _prepare_acquire_kwargs(
         self,
         kwargs: dict,
-        timeout: Optional[float],
+        timeout: float,
     ) -> dict:
         prepared_kwargs = super()._prepare_acquire_kwargs(kwargs, timeout)
         prepared_kwargs["timeout"] = timeout

--- a/hasql/asyncsqlalchemy.py
+++ b/hasql/asyncsqlalchemy.py
@@ -13,6 +13,8 @@ from hasql.utils import Dsn
 
 
 class PoolManager(BasePoolManager):
+    # TODO: _timeout is a smuggled kwarg key — consider returning a
+    #  (kwargs, timeout) tuple from _prepare_acquire_kwargs instead.
     def _prepare_acquire_kwargs(
         self,
         kwargs: dict,

--- a/hasql/asyncsqlalchemy.py
+++ b/hasql/asyncsqlalchemy.py
@@ -7,18 +7,31 @@ from sqlalchemy.ext.asyncio import AsyncConnection, AsyncSession
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 from sqlalchemy.pool import QueuePool
 
-from hasql.base import BasePoolManager
+from hasql.base import BasePoolManager, TimeoutAcquireContext
 from hasql.metrics import DriverMetrics
 from hasql.utils import Dsn
 
 
 class PoolManager(BasePoolManager):
+    def _prepare_acquire_kwargs(
+        self,
+        kwargs: dict,
+        timeout: Optional[float],
+    ) -> dict:
+        prepared_kwargs = super()._prepare_acquire_kwargs(kwargs, timeout)
+        prepared_kwargs["_timeout"] = timeout
+        return prepared_kwargs
+
     def get_pool_freesize(self, pool: AsyncEngine):
         queue_pool: QueuePool = pool.sync_engine.pool
         return queue_pool.size() - queue_pool.checkedout()
 
     def acquire_from_pool(self, pool: AsyncEngine, **kwargs):
-        return pool.connect()
+        timeout = kwargs.pop("_timeout", None)
+        ctx = pool.connect()
+        if timeout is not None:
+            return TimeoutAcquireContext(ctx, timeout)
+        return ctx
 
     async def release_to_pool(      # type: ignore
         self,

--- a/hasql/asyncsqlalchemy.py
+++ b/hasql/asyncsqlalchemy.py
@@ -16,7 +16,7 @@ class PoolManager(BasePoolManager):
     def _prepare_acquire_kwargs(
         self,
         kwargs: dict,
-        timeout: Optional[float],
+        timeout: float,
     ) -> dict:
         prepared_kwargs = super()._prepare_acquire_kwargs(kwargs, timeout)
         prepared_kwargs["_timeout"] = timeout

--- a/hasql/base.py
+++ b/hasql/base.py
@@ -72,7 +72,7 @@ class PoolAcquireContext(AsyncContextManager):
         pool_manager: "BasePoolManager",
         read_only: bool,
         master_as_replica_weight: Optional[float],
-        timeout: Optional[float],
+        timeout: float,
         metrics: CalculateMetrics,
         fallback_master: bool = False,
         **kwargs,
@@ -87,21 +87,16 @@ class PoolAcquireContext(AsyncContextManager):
         self.context: Any = None
         self.metrics = metrics
 
-    def _deadline(self) -> Optional[float]:
-        if self.timeout is None:
-            return None
+    def _deadline(self) -> float:
         return asyncio.get_running_loop().time() + self.timeout
 
-    def _remaining_timeout(self, deadline: Optional[float]) -> Optional[float]:
-        if deadline is None:
-            return None
-
+    def _remaining_timeout(self, deadline: float) -> float:
         remaining_timeout = deadline - asyncio.get_running_loop().time()
         if remaining_timeout <= 0:
             raise asyncio.TimeoutError
         return remaining_timeout
 
-    async def _get_pool(self, deadline: Optional[float]):
+    async def _get_pool(self, deadline: float):
         async def get_pool() -> Any:
             with self.metrics.with_get_pool():
                 return await self.pool_manager.balancer.get_pool(
@@ -116,7 +111,7 @@ class PoolAcquireContext(AsyncContextManager):
         )
         return self.pool
 
-    def _acquire_kwargs(self, deadline: Optional[float]) -> dict:
+    def _acquire_kwargs(self, deadline: float) -> dict:
         return self.pool_manager._prepare_acquire_kwargs(
             self.kwargs,
             timeout=self._remaining_timeout(deadline),
@@ -313,7 +308,7 @@ class BasePoolManager(ABC):
     def _prepare_acquire_kwargs(
         self,
         kwargs: dict,
-        timeout: Optional[float],
+        timeout: float,
     ) -> dict:
         return dict(kwargs)
 

--- a/hasql/base.py
+++ b/hasql/base.py
@@ -36,6 +36,10 @@ class TimeoutAcquireContext:
         )
 
     async def __aexit__(self, *exc):
+        # TODO: consider adding a bounded timeout here. Currently if the
+        #  underlying driver hangs during connection release this will block
+        #  indefinitely. A timeout risks leaking the connection (not returned
+        #  to pool), so this needs careful design.
         await self._context.__aexit__(*exc)
 
     def __await__(self):
@@ -96,6 +100,9 @@ class PoolAcquireContext(AsyncContextManager):
             raise asyncio.TimeoutError
         return remaining_timeout
 
+    # TODO: make _get_pool a clean function (return pool without mutating
+    #  self.pool) and extract the shared preamble between __aenter__ /
+    #  acquire_from_pool_connection into a helper.
     async def _get_pool(self, deadline: float):
         async def get_pool() -> Any:
             with self.metrics.with_get_pool():
@@ -117,10 +124,13 @@ class PoolAcquireContext(AsyncContextManager):
             timeout=self._remaining_timeout(deadline),
         )
 
-    async def acquire_from_pool_connection(self):
+    async def _resolve_pool_and_kwargs(self):
         deadline = self._deadline()
         await self._get_pool(deadline)
-        acquire_kwargs = self._acquire_kwargs(deadline)
+        return self._acquire_kwargs(deadline)
+
+    async def acquire_from_pool_connection(self):
+        acquire_kwargs = await self._resolve_pool_and_kwargs()
 
         with self.metrics.with_acquire(self.pool_manager.host(self.pool)):
             self.conn = await self.pool_manager.acquire_from_pool(
@@ -133,9 +143,7 @@ class PoolAcquireContext(AsyncContextManager):
         return self.conn
 
     async def __aenter__(self):
-        deadline = self._deadline()
-        await self._get_pool(deadline)
-        acquire_kwargs = self._acquire_kwargs(deadline)
+        acquire_kwargs = await self._resolve_pool_and_kwargs()
 
         with self.metrics.with_acquire(self.pool_manager.host(self.pool)):
             self.context = self.pool_manager.acquire_from_pool(

--- a/hasql/base.py
+++ b/hasql/base.py
@@ -4,8 +4,17 @@ from abc import ABC, abstractmethod
 from collections import defaultdict
 from itertools import chain
 from types import MappingProxyType
-from typing import (Any, AsyncContextManager, DefaultDict, Dict, List,
-                    Optional, Sequence, Set, Union)
+from typing import (
+    Any,
+    AsyncContextManager,
+    DefaultDict,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    Set,
+    Union,
+)
 
 from .metrics import CalculateMetrics, DriverMetrics, Metrics
 from .utils import Dsn, Stopwatch, split_dsn
@@ -35,10 +44,11 @@ class TimeoutAcquireContext:
             timeout=self._timeout,
         ).__await__()
 
+
 DEFAULT_REFRESH_DELAY: int = 1
 DEFAULT_REFRESH_TIMEOUT: int = 30
 DEFAULT_ACQUIRE_TIMEOUT: float = 1.0
-DEFAULT_MASTER_AS_REPLICA_WEIGHT: float = 0.
+DEFAULT_MASTER_AS_REPLICA_WEIGHT: float = 0.0
 DEFAULT_STOPWATCH_WINDOW_SIZE: int = 128
 
 
@@ -57,15 +67,14 @@ class AbstractBalancerPolicy(ABC):
 
 
 class PoolAcquireContext(AsyncContextManager):
-
     def __init__(
         self,
         pool_manager: "BasePoolManager",
         read_only: bool,
-        fallback_master: Optional[bool],
         master_as_replica_weight: Optional[float],
         timeout: Optional[float],
         metrics: CalculateMetrics,
+        fallback_master: bool = False,
         **kwargs,
     ):
         self.pool_manager = pool_manager
@@ -74,8 +83,8 @@ class PoolAcquireContext(AsyncContextManager):
         self.master_as_replica_weight = master_as_replica_weight
         self.timeout = timeout
         self.kwargs = kwargs
-        self.pool = None
-        self.context = None
+        self.pool: Any = None
+        self.context: Any = None
         self.metrics = metrics
 
     def _deadline(self) -> Optional[float]:
@@ -120,7 +129,8 @@ class PoolAcquireContext(AsyncContextManager):
 
         with self.metrics.with_acquire(self.pool_manager.host(self.pool)):
             self.conn = await self.pool_manager.acquire_from_pool(
-                self.pool, **acquire_kwargs,
+                self.pool,
+                **acquire_kwargs,
             )
 
         self.metrics.add_connection(self.pool_manager.host(self.pool))
@@ -178,6 +188,7 @@ class BasePoolManager(ABC):
         if balancer_policy is AbstractBalancerPolicy:
             # Avoid circular import
             from .balancer_policy.greedy import GreedyBalancerPolicy
+
             balancer_policy = GreedyBalancerPolicy
 
         if pool_factory_kwargs is None:
@@ -322,9 +333,8 @@ class BasePoolManager(ABC):
                 "Field master_as_replica_weight is used only when "
                 "read_only is True",
             )
-        if (
-            master_as_replica_weight is not None and
-            not (0. <= master_as_replica_weight <= 1)
+        if master_as_replica_weight is not None and not (
+            0.0 <= master_as_replica_weight <= 1
         ):
             raise ValueError(
                 "Field master_as_replica_weight must belong "
@@ -351,7 +361,9 @@ class BasePoolManager(ABC):
         return ctx
 
     def acquire_master(
-        self, timeout: Optional[float] = None, **kwargs,
+        self,
+        timeout: Optional[float] = None,
+        **kwargs,
     ):
         return self.acquire(read_only=False, timeout=timeout, **kwargs)
 
@@ -417,9 +429,8 @@ class BasePoolManager(ABC):
         timeout: int = 10,
     ):
 
-        if (
-            (masters_count is not None and replicas_count is None) or
-            (masters_count is None and replicas_count is not None)
+        if (masters_count is not None and replicas_count is None) or (
+            masters_count is None and replicas_count is not None
         ):
             raise ValueError(
                 "Arguments master_count and replicas_count "
@@ -442,7 +453,8 @@ class BasePoolManager(ABC):
             asyncio.gather(
                 self.wait_masters_ready(masters_count),
                 self.wait_replicas_ready(replicas_count),
-            ), timeout=timeout,
+            ),
+            timeout=timeout,
         )
 
     async def wait_all_ready(self):
@@ -529,10 +541,12 @@ class BasePoolManager(ABC):
                 # Не использовать async with self.acquire_from_pool(pool)
                 # из-за большого таймаута
                 logger.debug(
-                    "Acquiring connection for checking dsn=%r", censored_dsn,
+                    "Acquiring connection for checking dsn=%r",
+                    censored_dsn,
                 )
                 sys_connection = await asyncio.wait_for(
-                    self.acquire_from_pool(pool), timeout=self._refresh_timeout,
+                    self.acquire_from_pool(pool),
+                    timeout=self._refresh_timeout,
                 )
 
                 logger.debug("Checking dsn=%r", censored_dsn)

--- a/hasql/base.py
+++ b/hasql/base.py
@@ -70,7 +70,7 @@ class PoolAcquireContext(AsyncContextManager):
         return remaining_timeout
 
     async def _get_pool(self, deadline: Optional[float]):
-        async def get_pool():
+        async def get_pool() -> Any:
             with self.metrics.with_get_pool():
                 return await self.pool_manager.balancer.get_pool(
                     read_only=self.read_only,

--- a/hasql/base.py
+++ b/hasql/base.py
@@ -41,7 +41,7 @@ class PoolAcquireContext(AsyncContextManager):
         read_only: bool,
         fallback_master: Optional[bool],
         master_as_replica_weight: Optional[float],
-        timeout: float,
+        timeout: Optional[float],
         metrics: CalculateMetrics,
         **kwargs,
     ):
@@ -55,41 +55,73 @@ class PoolAcquireContext(AsyncContextManager):
         self.context = None
         self.metrics = metrics
 
-    async def acquire_from_pool_connection(self):
-        async def execute():
+    def _deadline(self) -> Optional[float]:
+        if self.timeout is None:
+            return None
+        return asyncio.get_running_loop().time() + self.timeout
+
+    def _remaining_timeout(self, deadline: Optional[float]) -> Optional[float]:
+        if deadline is None:
+            return None
+
+        remaining_timeout = deadline - asyncio.get_running_loop().time()
+        if remaining_timeout <= 0:
+            raise asyncio.TimeoutError
+        return remaining_timeout
+
+    async def _get_pool(self, deadline: Optional[float]):
+        async def get_pool():
             with self.metrics.with_get_pool():
-                self.pool = await self.pool_manager.balancer.get_pool(
+                return await self.pool_manager.balancer.get_pool(
                     read_only=self.read_only,
                     fallback_master=self.fallback_master,
                     master_as_replica_weight=self.master_as_replica_weight,
                 )
 
-            with self.metrics.with_acquire(self.pool_manager.host(self.pool)):
-                return await self.pool_manager.acquire_from_pool(
-                    self.pool, **self.kwargs,
-                )
+        self.pool = await asyncio.wait_for(
+            get_pool(),
+            timeout=self._remaining_timeout(deadline),
+        )
+        return self.pool
 
-        self.conn = await asyncio.wait_for(execute(), timeout=self.timeout)
+    def _acquire_kwargs(self, deadline: Optional[float]) -> dict:
+        return self.pool_manager._prepare_acquire_kwargs(
+            self.kwargs,
+            timeout=self._remaining_timeout(deadline),
+        )
+
+    async def acquire_from_pool_connection(self):
+        deadline = self._deadline()
+        await self._get_pool(deadline)
+        acquire_kwargs = self._acquire_kwargs(deadline)
+
+        with self.metrics.with_acquire(self.pool_manager.host(self.pool)):
+            self.conn = await asyncio.wait_for(
+                self.pool_manager.acquire_from_pool(
+                    self.pool, **acquire_kwargs,
+                ),
+                timeout=self._remaining_timeout(deadline),
+            )
+
         self.metrics.add_connection(self.pool_manager.host(self.pool))
         self.pool_manager.register_connection(self.conn, self.pool)
         return self.conn
 
     async def __aenter__(self):
-        async def go():
-            with self.metrics.with_get_pool():
-                self.pool = await self.pool_manager.balancer.get_pool(
-                    read_only=self.read_only,
-                    fallback_master=self.fallback_master,
-                    master_as_replica_weight=self.master_as_replica_weight,
-                )
-            with self.metrics.with_acquire(self.pool_manager.host(self.pool)):
-                self.context = self.pool_manager.acquire_from_pool(
-                    self.pool,
-                    **self.kwargs,
-                )
-            return await self.context.__aenter__()
+        deadline = self._deadline()
+        await self._get_pool(deadline)
+        acquire_kwargs = self._acquire_kwargs(deadline)
 
-        self.conn = await asyncio.wait_for(go(), timeout=self.timeout)
+        with self.metrics.with_acquire(self.pool_manager.host(self.pool)):
+            self.context = self.pool_manager.acquire_from_pool(
+                self.pool,
+                **acquire_kwargs,
+            )
+            self.conn = await asyncio.wait_for(
+                self.context.__aenter__(),
+                timeout=self._remaining_timeout(deadline),
+            )
+
         self.metrics.add_connection(self.pool_manager.host(self.pool))
         return self.conn
 
@@ -249,6 +281,13 @@ class BasePoolManager(ABC):
             drivers=self._driver_metrics(),
             hasql=self._metrics.metrics(),
         )
+
+    def _prepare_acquire_kwargs(
+        self,
+        kwargs: dict,
+        timeout: Optional[float],
+    ) -> dict:
+        return dict(kwargs)
 
     def acquire(
         self,
@@ -486,6 +525,8 @@ class BasePoolManager(ABC):
                     "Creating system connection failed for dsn=%r",
                     censored_dsn,
                 )
+                self._remove_pool_from_master_set(pool, dsn)
+                self._remove_pool_from_replica_set(pool, dsn)
             except asyncio.CancelledError as cancelled_error:
                 if self._closing:
                     raise cancelled_error from None
@@ -508,19 +549,19 @@ class BasePoolManager(ABC):
                 if sys_connection is not None:
                     try:
                         await self.release_to_pool(sys_connection, pool)
-                    except (Exception, asyncio.CancelledError):
-                        logger.warning(
-                            "Release connection to pool with "
-                            "exception for dsn=%r",
-                            censored_dsn,
-                            exc_info=True,
-                        )
                     except asyncio.CancelledError as cancelled_error:
                         if self._closing:
                             raise cancelled_error from None
                         logger.warning(
                             "Release connection to pool with "
                             "Cancelled error for dsn=%r",
+                            censored_dsn,
+                            exc_info=True,
+                        )
+                    except Exception:
+                        logger.warning(
+                            "Release connection to pool with "
+                            "exception for dsn=%r",
                             censored_dsn,
                             exc_info=True,
                         )

--- a/hasql/base.py
+++ b/hasql/base.py
@@ -12,6 +12,29 @@ from .utils import Dsn, Stopwatch, split_dsn
 
 logger = logging.getLogger(__name__)
 
+
+class TimeoutAcquireContext:
+    __slots__ = ("_context", "_timeout")
+
+    def __init__(self, context, timeout: float):
+        self._context = context
+        self._timeout = timeout
+
+    async def __aenter__(self):
+        return await asyncio.wait_for(
+            self._context.__aenter__(),
+            timeout=self._timeout,
+        )
+
+    async def __aexit__(self, *exc):
+        await self._context.__aexit__(*exc)
+
+    def __await__(self):
+        return asyncio.wait_for(
+            self._context.__aenter__(),
+            timeout=self._timeout,
+        ).__await__()
+
 DEFAULT_REFRESH_DELAY: int = 1
 DEFAULT_REFRESH_TIMEOUT: int = 30
 DEFAULT_ACQUIRE_TIMEOUT: float = 1.0
@@ -96,11 +119,8 @@ class PoolAcquireContext(AsyncContextManager):
         acquire_kwargs = self._acquire_kwargs(deadline)
 
         with self.metrics.with_acquire(self.pool_manager.host(self.pool)):
-            self.conn = await asyncio.wait_for(
-                self.pool_manager.acquire_from_pool(
-                    self.pool, **acquire_kwargs,
-                ),
-                timeout=self._remaining_timeout(deadline),
+            self.conn = await self.pool_manager.acquire_from_pool(
+                self.pool, **acquire_kwargs,
             )
 
         self.metrics.add_connection(self.pool_manager.host(self.pool))
@@ -117,10 +137,7 @@ class PoolAcquireContext(AsyncContextManager):
                 self.pool,
                 **acquire_kwargs,
             )
-            self.conn = await asyncio.wait_for(
-                self.context.__aenter__(),
-                timeout=self._remaining_timeout(deadline),
-            )
+            self.conn = await self.context.__aenter__()
 
         self.metrics.add_connection(self.pool_manager.host(self.pool))
         return self.conn
@@ -668,4 +685,8 @@ class BasePoolManager(ABC):
         await self.close()
 
 
-__all__ = ("BasePoolManager", "AbstractBalancerPolicy")
+__all__ = (
+    "BasePoolManager",
+    "AbstractBalancerPolicy",
+    "TimeoutAcquireContext",
+)

--- a/hasql/psycopg3.py
+++ b/hasql/psycopg3.py
@@ -41,13 +41,14 @@ class PoolAcquireContext:
 class PoolManager(BasePoolManager):
     pools: Sequence[AsyncConnectionPool]
 
-    def __init__(self, dsn: str, **kwargs):
-        pool_factory_kwargs = kwargs.pop("pool_factory_kwargs", {})
-        pool_factory_kwargs["max_waiting"] = -1
-        super().__init__(
-            dsn,
-            pool_factory_kwargs=pool_factory_kwargs, **kwargs
-        )
+    def _prepare_acquire_kwargs(
+        self,
+        kwargs: dict,
+        timeout: Optional[float],
+    ) -> dict:
+        prepared_kwargs = super()._prepare_acquire_kwargs(kwargs, timeout)
+        prepared_kwargs["timeout"] = timeout
+        return prepared_kwargs
 
     def get_pool_freesize(self, pool: AsyncConnectionPool):
         return pool.get_stats()["pool_available"]

--- a/hasql/psycopg3.py
+++ b/hasql/psycopg3.py
@@ -44,7 +44,7 @@ class PoolManager(BasePoolManager):
     def _prepare_acquire_kwargs(
         self,
         kwargs: dict,
-        timeout: Optional[float],
+        timeout: float,
     ) -> dict:
         prepared_kwargs = super()._prepare_acquire_kwargs(kwargs, timeout)
         prepared_kwargs["timeout"] = timeout

--- a/tests/test_aiopg.py
+++ b/tests/test_aiopg.py
@@ -69,3 +69,14 @@ async def test_driver_metrics(pool_manager, pg_dsn):
     assert pool_manager.metrics().drivers == [
         DriverMetrics(max=11, min=11, idle=9, used=2, host=mock.ANY)
     ]
+
+
+def test_prepare_acquire_kwargs_sets_timeout():
+    pool_manager = PoolManager.__new__(PoolManager)
+    assert pool_manager._prepare_acquire_kwargs(
+        {"some_kwarg": 1},
+        timeout=0.25,
+    ) == {
+        "some_kwarg": 1,
+        "_timeout": 0.25,
+    }

--- a/tests/test_asyncpg.py
+++ b/tests/test_asyncpg.py
@@ -58,3 +58,14 @@ async def test_metrics(pool_manager):
         assert pool_manager.metrics().drivers == [
             DriverMetrics(max=11, min=11, idle=9, used=2, host=mock.ANY)
         ]
+
+
+def test_prepare_acquire_kwargs_sets_timeout():
+    pool_manager = PoolManager.__new__(PoolManager)
+    assert pool_manager._prepare_acquire_kwargs(
+        {"statement_cache_size": 0},
+        timeout=0.25,
+    ) == {
+        "statement_cache_size": 0,
+        "timeout": 0.25,
+    }

--- a/tests/test_asyncsqlalchemy.py
+++ b/tests/test_asyncsqlalchemy.py
@@ -9,6 +9,17 @@ from hasql.asyncsqlalchemy import PoolManager, async_sessionmaker
 from hasql.metrics import DriverMetrics
 
 
+def test_prepare_acquire_kwargs_sets_timeout():
+    pool_manager = PoolManager.__new__(PoolManager)
+    assert pool_manager._prepare_acquire_kwargs(
+        {"some_kwarg": 1},
+        timeout=0.25,
+    ) == {
+        "some_kwarg": 1,
+        "_timeout": 0.25,
+    }
+
+
 @pytest.fixture
 async def pool_manager(pg_dsn):
     pg_pool = PoolManager(

--- a/tests/test_balancer_policy.py
+++ b/tests/test_balancer_policy.py
@@ -33,7 +33,9 @@ def make_dsn():
 
 
 @pytest.fixture
-def make_pool_manager(make_dsn):
+async def make_pool_manager(make_dsn):
+    pool_managers = []
+
     async def make(balancer_policy, replicas_count: int = 2):
         pool_manager = TestPoolManager(
             dsn=make_dsn(replicas_count),
@@ -42,9 +44,16 @@ def make_pool_manager(make_dsn):
             refresh_delay=0.1,
             acquire_timeout=0.1,
         )
+        pool_managers.append(pool_manager)
         return pool_manager
 
-    return make
+    try:
+        yield make
+    finally:
+        await asyncio.gather(
+            *(pool_manager.close() for pool_manager in pool_managers),
+            return_exceptions=True,
+        )
 
 
 @balancer_policies

--- a/tests/test_psycopg3.py
+++ b/tests/test_psycopg3.py
@@ -3,8 +3,10 @@ from contextlib import AsyncExitStack
 
 import mock
 import pytest
+pytest.importorskip("psycopg")
+pytest.importorskip("psycopg_pool")
 from psycopg import AsyncConnection
-from psycopg_pool import TooManyRequests
+from psycopg_pool import PoolTimeout, TooManyRequests
 
 from hasql.metrics import DriverMetrics
 from hasql.psycopg3 import PoolManager
@@ -73,7 +75,7 @@ async def test_acquire_with_timeout_context(pool_manager, pool_size):
     for _ in range(pool_size):
         conns.append(await pool_manager.acquire_master())
 
-    with pytest.raises(TooManyRequests):
+    with pytest.raises(PoolTimeout):
         await pool_manager.acquire_master()
 
     for conn in conns:
@@ -88,23 +90,56 @@ async def test_acquire_with_timeout_context(pool_manager, pool_size):
             pass
 
 
-async def test_acquire_with_timeout_context2(pool_manager, pool_size):
+@pytest.fixture
+async def queue_limited_pool_manager(pg_dsn, pool_size):
+    pg_pool = PoolManager(
+        dsn=pg_dsn,
+        fallback_master=True,
+        acquire_timeout=1,
+        pool_factory_kwargs={
+            "min_size": pool_size,
+            "max_size": pool_size,
+            "max_waiting": 1,
+        },
+    )
+    try:
+        await pg_pool.ready()
+        yield pg_pool
+    finally:
+        await pg_pool.close()
+
+
+async def test_acquire_with_queue_limit(queue_limited_pool_manager, pool_size):
     async with AsyncExitStack() as stack:
         for _ in range(pool_size):
-            await stack.enter_async_context(pool_manager.acquire_master())
+            await stack.enter_async_context(
+                queue_limited_pool_manager.acquire_master(),
+            )
 
-            async def wait_for_smth():
-                with pytest.raises(TooManyRequests):
-                    async with pool_manager.acquire_master():
-                        pass
+        async def wait_for_connection():
+            conn = await queue_limited_pool_manager.acquire_master()
+            await queue_limited_pool_manager.release(conn)
 
-        await asyncio.gather(*[wait_for_smth() for _ in range(pool_size)])
+        waiter = asyncio.create_task(wait_for_connection())
+        await asyncio.sleep(0.1)
 
-    for pool in pool_manager.pools:
-        assert pool_manager.get_pool_freesize(pool) == pool_size
+        with pytest.raises(TooManyRequests):
+            await queue_limited_pool_manager.acquire_master()
 
-    async with AsyncExitStack() as stack:
-        await stack.enter_async_context(pool_manager.acquire_master())
+        assert not waiter.done()
+
+    await waiter
+
+
+def test_prepare_acquire_kwargs_sets_timeout():
+    pool_manager = PoolManager.__new__(PoolManager)
+    assert pool_manager._prepare_acquire_kwargs(
+        {"row_factory": mock.ANY},
+        timeout=0.25,
+    ) == {
+        "row_factory": mock.ANY,
+        "timeout": 0.25,
+    }
 
 
 async def test_metrics(pool_manager):

--- a/tests/test_timeout_handling.py
+++ b/tests/test_timeout_handling.py
@@ -31,6 +31,18 @@ class SlowAcquire:
         return self.wait().__await__()
 
 
+class _TimeoutSlowAcquire:
+    def __init__(self, slow_acquire: SlowAcquire, timeout: float):
+        self._slow_acquire = slow_acquire
+        self._timeout = timeout
+
+    def __await__(self):
+        return asyncio.wait_for(
+            self._slow_acquire.wait(),
+            timeout=self._timeout,
+        ).__await__()
+
+
 class RecordingPoolManager:
     def __init__(self, pool_delay: float, acquire_delay: float):
         self.pool = object()
@@ -45,7 +57,11 @@ class RecordingPoolManager:
 
     def acquire_from_pool(self, pool, **kwargs):
         self.acquire_kwargs = kwargs
-        return SlowAcquire(self.acquire_delay)
+        timeout = kwargs.get("timeout")
+        slow = SlowAcquire(self.acquire_delay)
+        if timeout is not None:
+            return _TimeoutSlowAcquire(slow, timeout)
+        return slow
 
     def host(self, pool):
         return "test-host:5432"

--- a/tests/test_timeout_handling.py
+++ b/tests/test_timeout_handling.py
@@ -1,0 +1,139 @@
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from hasql.base import PoolAcquireContext
+from hasql.metrics import CalculateMetrics
+from tests.mocks import TestPoolManager
+from tests.mocks.pool_manager import TestPool
+
+
+class DelayedBalancer:
+    def __init__(self, pool, delay: float):
+        self.pool = pool
+        self.delay = delay
+
+    async def get_pool(self, **kwargs):
+        await asyncio.sleep(self.delay)
+        return self.pool
+
+
+class SlowAcquire:
+    def __init__(self, delay: float):
+        self.delay = delay
+
+    async def wait(self):
+        await asyncio.sleep(self.delay)
+        return object()
+
+    def __await__(self):
+        return self.wait().__await__()
+
+
+class RecordingPoolManager:
+    def __init__(self, pool_delay: float, acquire_delay: float):
+        self.pool = object()
+        self.balancer = DelayedBalancer(self.pool, delay=pool_delay)
+        self.acquire_delay = acquire_delay
+        self.acquire_kwargs = None
+
+    def _prepare_acquire_kwargs(self, kwargs: dict, timeout):
+        prepared_kwargs = dict(kwargs)
+        prepared_kwargs["timeout"] = timeout
+        return prepared_kwargs
+
+    def acquire_from_pool(self, pool, **kwargs):
+        self.acquire_kwargs = kwargs
+        return SlowAcquire(self.acquire_delay)
+
+    def host(self, pool):
+        return "test-host:5432"
+
+    def register_connection(self, connection, pool):
+        pass
+
+
+class OneConnectionPoolManager(TestPoolManager):
+    async def _pool_factory(self, dsn):
+        return TestPool(str(dsn), maxsize=1)
+
+
+class ReacquiringOneConnectionPoolManager(OneConnectionPoolManager):
+    async def _periodic_pool_check(self, pool, dsn, sys_connection):
+        await asyncio.wait_for(
+            self._refresh_pool_role(pool, dsn, sys_connection),
+            timeout=self._refresh_timeout,
+        )
+        await self._notify_about_pool_has_checked(dsn)
+
+
+async def wait_until(predicate, timeout: float = 1.0):
+    deadline = asyncio.get_running_loop().time() + timeout
+    while not predicate():
+        if asyncio.get_running_loop().time() >= deadline:
+            raise AssertionError("condition was not met before timeout")
+        await asyncio.sleep(0.01)
+
+
+async def test_acquire_timeout_uses_shared_budget():
+    pool_manager = RecordingPoolManager(pool_delay=0.05, acquire_delay=1.0)
+    context = PoolAcquireContext(
+        pool_manager=pool_manager,
+        read_only=False,
+        fallback_master=False,
+        master_as_replica_weight=None,
+        timeout=0.1,
+        metrics=CalculateMetrics(),
+    )
+
+    start = asyncio.get_running_loop().time()
+    with pytest.raises(asyncio.TimeoutError):
+        await context
+
+    elapsed = asyncio.get_running_loop().time() - start
+    assert elapsed < 0.2
+    assert pool_manager.acquire_kwargs is not None
+    assert 0 < pool_manager.acquire_kwargs["timeout"] < 0.1
+
+
+async def test_refresh_timeout_removes_pool_from_available_set():
+    pool_manager = ReacquiringOneConnectionPoolManager(
+        "postgresql://test:test@master:5432/test",
+        refresh_timeout=0.2,
+        refresh_delay=0.2,
+        acquire_timeout=0.5,
+    )
+    try:
+        await pool_manager.ready()
+        connection = await pool_manager.acquire_master()
+
+        await wait_until(lambda: pool_manager.master_pool_count == 0)
+
+        await pool_manager.release(connection)
+        await wait_until(lambda: pool_manager.master_pool_count == 1)
+    finally:
+        await pool_manager.close()
+
+
+async def test_close_preserves_cancellation_during_sys_connection_release():
+    pool_manager = TestPoolManager(
+        "postgresql://test:test@master,replica1,replica2/test",
+        refresh_timeout=0.2,
+        refresh_delay=0.05,
+    )
+    try:
+        await pool_manager.ready()
+        refresh_tasks = list(pool_manager._refresh_role_tasks)
+        pool_manager.release_to_pool = AsyncMock(
+            side_effect=asyncio.CancelledError(),
+        )
+
+        await pool_manager.close()
+
+        assert pool_manager.closed
+        assert pool_manager.release_to_pool.await_count > 0
+        assert all(task.done() for task in refresh_tasks)
+    finally:
+        if not pool_manager.closed:
+            await pool_manager.close()


### PR DESCRIPTION
### Problem                                                                                                                                                                                                                                    
   
  When acquiring a connection from the pool, acquire_timeout was applied as a single asyncio.wait_for wrapping the entire process — both pool selection and driver-level connection acquisition. This caused three issues:                   
                                                                                                                                                                                                                                           
  1. Double timeout — base.py wrapped the call in asyncio.wait_for, while some drivers (asyncpg, psycopg3) simultaneously applied their own native timeout. The effective timeout was unpredictable.                                         
  2. Unavailable pools were not excluded — when a health-check timed out (refresh_timeout), the pool was not removed from the master/replica sets, and the balancer continued handing it out to clients.                                   
  3. Incorrect exception handler ordering — in _check_pool_task, the except (Exception, asyncio.CancelledError) block caught CancelledError before the specialized handler, making it dead code.                                             
                                                                                                                                                                                                                                             
  ### Solution                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                             
  **Timeout budget**                                                                                                                                                                                                                             
   
  The single acquire_timeout is now split between two phases:                                                                                                                                                                                
                                                                                                                                                                                                                                           
  1. Pool selection — _get_pool(deadline) waits up to deadline - now.                                                                                                                                                                        
  2. Connection acquisition — the remaining budget is forwarded to the driver via _prepare_acquire_kwargs.                                                                                                                                 
                                                                                                                                                                                                                                             
  Each driver adapter enforces the remaining budget using its native mechanism:
                                                                                                                                                                                                                                             
  | Driver | Mechanism |
|------------------|-------------------------------------------------------------------------|
| asyncpg | pool.acquire(timeout=remaining) |
| psycopg3 | pool.getconn(timeout=remaining) |
| aiopg / aiopg_sa | asyncio.wait_for(pool.acquire(), timeout=remaining) via TimeoutAcquireContext |
| asyncsqlalchemy | asyncio.wait_for(pool.connect(), timeout=remaining) via TimeoutAcquireContext |                                                                                                                          
                                                                                                                                                                                                                                           
  **Excluding unavailable pools**
   
  On asyncio.TimeoutError in _check_pool_task, the pool is now removed from both _master_pool_set and _replica_pool_set.                                                                                                                     
                                                                                                                                                                                                                                           
  **CancelledError handling fix**                                                                                                                                                                                                                
   
  In the finally block of _check_pool_task, the except order is corrected: CancelledError is now caught before Exception. When _closing=True, the error is re-raised for graceful shutdown.                                                  
                                                                                                                