### PR TITLE
feat(staleness): add replication lag detection with tiered fallback

### DIFF
--- a/hasql/balancer_policy/base.py
+++ b/hasql/balancer_policy/base.py
@@ -44,11 +44,24 @@ class AbstractBalancerPolicy(ABC, Generic[PoolT]):
         candidates: list[PoolT] = []
 
         if read_only:
-            candidates.extend(
-                await self._pool_state.get_replica_pools(
-                    fallback_master=fallback_master,
-                ),
-            )
+            if self._pool_state.replica_pool_count > 0:
+                candidates.extend(
+                    await self._pool_state.get_replica_pools(
+                        fallback_master=False,
+                    ),
+                )
+            elif fallback_master and self._pool_state.master_pool_count > 0:
+                candidates.extend(
+                    await self._pool_state.get_master_pools(),
+                )
+            elif self._pool_state.stale_pool_count > 0:
+                candidates.extend(self._pool_state.get_stale_pools())
+            else:
+                candidates.extend(
+                    await self._pool_state.get_replica_pools(
+                        fallback_master=fallback_master,
+                    ),
+                )
 
         if not read_only or (
             choose_master_as_replica

--- a/hasql/health.py
+++ b/hasql/health.py
@@ -59,9 +59,7 @@ class PoolHealthMonitor(Generic[PoolT, ConnT]):
         while not self._closing():
             try:
                 await asyncio.wait_for(
-                    self._pool_state.refresh_pool_role(
-                        pool, dsn, sys_connection,
-                    ),
+                    self._full_pool_check(pool, dsn, sys_connection),
                     timeout=self._refresh_timeout,
                 )
                 await self._pool_state.notify_pool_checked(dsn)
@@ -74,6 +72,30 @@ class PoolHealthMonitor(Generic[PoolT, ConnT]):
                 await self._pool_state.notify_pool_checked(dsn)
 
             await asyncio.sleep(self._refresh_delay)
+
+    async def _full_pool_check(
+        self,
+        pool: PoolT,
+        dsn: Dsn,
+        sys_connection: ConnT,
+    ):
+        was_stale = self._pool_state.pool_is_stale(pool)
+        await self._pool_state.refresh_pool_role(pool, dsn, sys_connection)
+        try:
+            if self._pool_state.pool_is_master(pool):
+                await self._pool_state.collect_master_state(sys_connection)
+            else:
+                await self._pool_state.check_replica_staleness(
+                    pool, dsn, sys_connection,
+                )
+        except Exception:
+            if was_stale and not self._pool_state.pool_is_master(pool):
+                self._pool_state.mark_pool_stale(pool)
+            logger.warning(
+                "Staleness check failed for dsn=%s",
+                dsn.with_(password="******"),
+                exc_info=True,
+            )
 
     async def _check_pool_task(self, index: int):
         logger.debug("Starting pool task")

--- a/hasql/metrics.py
+++ b/hasql/metrics.py
@@ -13,6 +13,11 @@ class PoolRole(str, Enum):
     REPLICA = "replica"
 
 
+class PoolStaleness(str, Enum):
+    FRESH = "fresh"
+    STALE = "stale"
+
+
 @dataclass(frozen=True)
 class PoolStats:
     """Raw pool statistics returned by a driver for a single pool."""
@@ -104,6 +109,8 @@ class PoolMetrics:
     used: int
     response_time: float | None
     in_flight: int
+    staleness: PoolStaleness | None = None
+    lag: dict[str, Any] = field(default_factory=dict)
     extra: dict[str, Any] = field(default_factory=dict)
 
 
@@ -116,6 +123,7 @@ class HasqlGauges:
     active_connections: int
     closing: bool
     closed: bool
+    stale_count: int = 0
     unavailable_count: int = 0
 
 
@@ -143,6 +151,7 @@ class Metrics:
 
 __all__ = (
     "PoolRole",
+    "PoolStaleness",
     "PoolStats",
     "DriverMetrics",
     "HasqlMetrics",

--- a/hasql/pool_manager.py
+++ b/hasql/pool_manager.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 from collections.abc import Sequence
 from typing import (
+    Any,
     Generic,
     TypeVar,
 )
@@ -25,8 +26,10 @@ from .metrics import (
     Metrics,
     PoolMetrics,
     PoolRole,
+    PoolStaleness,
 )
 from .pool_state import PoolState
+from .staleness import StalenessPolicy
 from .utils import Dsn, split_dsn
 
 logger = logging.getLogger(__name__)
@@ -51,6 +54,7 @@ class BasePoolManager(Generic[PoolT, ConnT]):
         balancer_policy: type[AbstractBalancerPolicy] = GreedyBalancerPolicy,
         stopwatch_window_size: int = DEFAULT_STOPWATCH_WINDOW_SIZE,
         pool_factory_kwargs: dict | None = None,
+        staleness: StalenessPolicy | None = None,
     ):
         if not issubclass(balancer_policy, AbstractBalancerPolicy):
             raise ValueError(
@@ -62,6 +66,7 @@ class BasePoolManager(Generic[PoolT, ConnT]):
             driver=driver,
             stopwatch_window_size=stopwatch_window_size,
             pool_factory_kwargs=pool_factory_kwargs,
+            staleness=staleness,
         )
 
         self._balancer: AbstractBalancerPolicy[PoolT] | None = (
@@ -193,6 +198,26 @@ class BasePoolManager(Generic[PoolT, ConnT]):
             else:
                 role = None
 
+            staleness = None
+            lag: dict[str, Any] = {}
+            if role == PoolRole.REPLICA:
+                check_result = pool_state.get_last_check_result(pool)
+                if check_result is not None:
+                    staleness = (
+                        PoolStaleness.FRESH
+                        if not check_result.is_stale
+                        else PoolStaleness.STALE
+                    )
+                    lag = check_result.lag
+                else:
+                    staleness = PoolStaleness.FRESH
+            elif pool_state.pool_is_stale(pool):
+                role = PoolRole.REPLICA
+                check_result = pool_state.get_last_check_result(pool)
+                staleness = PoolStaleness.STALE
+                if check_result is not None:
+                    lag = check_result.lag
+
             in_flight = sum(
                 1 for p in self._unmanaged_connections.values() if p is pool
             )
@@ -207,6 +232,8 @@ class BasePoolManager(Generic[PoolT, ConnT]):
                 used=stats.used,
                 response_time=pool_state.get_last_response_time(pool),
                 in_flight=in_flight,
+                staleness=staleness,
+                lag=lag,
                 extra=stats.extra,
             ))
 
@@ -217,6 +244,7 @@ class BasePoolManager(Generic[PoolT, ConnT]):
             active_connections=len(self._unmanaged_connections),
             closing=self._closing,
             closed=self._closed,
+            stale_count=pool_state.stale_pool_count,
             unavailable_count=(
                 len([p for p in pool_state.pools if p is not None])
                 - pool_state.available_pool_count

--- a/hasql/pool_state.py
+++ b/hasql/pool_state.py
@@ -14,6 +14,7 @@ from typing import (
 from .abc import PoolDriver
 from .acquire import AcquireContext
 from .metrics import PoolStats
+from .staleness import CheckContext, StalenessCheckResult, StalenessPolicy
 from .utils import Dsn, Stopwatch
 
 logger = logging.getLogger(__name__)
@@ -28,10 +29,13 @@ class PoolStateProvider(Protocol[PoolT]):
     def master_pool_count(self) -> int: ...
     @property
     def replica_pool_count(self) -> int: ...
+    @property
+    def stale_pool_count(self) -> int: ...
     async def get_master_pools(self) -> list[PoolT]: ...
     async def get_replica_pools(
         self, fallback_master: bool = False,
     ) -> list[PoolT]: ...
+    def get_stale_pools(self) -> list[PoolT]: ...
     def get_pool_freesize(self, pool: PoolT) -> int: ...
     def get_last_response_time(self, pool: PoolT) -> float | None: ...
 
@@ -44,6 +48,7 @@ class PoolState(Generic[PoolT, ConnT]):
     _dsn_check_cond: defaultdict[Dsn, asyncio.Condition]
     _master_pool_set: set[PoolT]
     _replica_pool_set: set[PoolT]
+    _stale_pool_set: set[PoolT]
 
     def __init__(
         self,
@@ -51,6 +56,7 @@ class PoolState(Generic[PoolT, ConnT]):
         driver: PoolDriver[PoolT, ConnT],
         stopwatch_window_size: int,
         pool_factory_kwargs: dict | None = None,
+        staleness: StalenessPolicy | None = None,
     ):
         self._driver = driver
         self._pool_factory_kwargs: MappingProxyType = MappingProxyType(
@@ -66,11 +72,14 @@ class PoolState(Generic[PoolT, ConnT]):
         self._dsn_check_cond = defaultdict(asyncio.Condition)
         self._master_pool_set: set[PoolT] = set()
         self._replica_pool_set: set[PoolT] = set()
+        self._stale_pool_set: set[PoolT] = set()
         self._master_cond = asyncio.Condition()
         self._replica_cond = asyncio.Condition()
         self._stopwatch: Stopwatch[PoolT] = Stopwatch(
             window_size=stopwatch_window_size,
         )
+        self._staleness: StalenessPolicy | None = staleness
+        self._last_check_result: dict[PoolT, StalenessCheckResult] = {}
 
     # --- Properties ---
 
@@ -99,8 +108,16 @@ class PoolState(Generic[PoolT, ConnT]):
         return len(self._replica_pool_set)
 
     @property
+    def stale_pool_count(self) -> int:
+        return len(self._stale_pool_set)
+
+    @property
     def available_pool_count(self) -> int:
-        return self.master_pool_count + self.replica_pool_count
+        return (
+            self.master_pool_count
+            + self.replica_pool_count
+            + self.stale_pool_count
+        )
 
     # --- Pool state queries ---
 
@@ -110,11 +127,20 @@ class PoolState(Generic[PoolT, ConnT]):
     def pool_is_replica(self, pool: PoolT) -> bool:
         return pool in self._replica_pool_set
 
+    def get_stale_pools(self) -> list[PoolT]:
+        return list(self._stale_pool_set)
+
     def get_pool_freesize(self, pool: PoolT) -> int:
         return self._driver.get_pool_freesize(pool)
 
     def get_last_response_time(self, pool: PoolT) -> float | None:
         return self._stopwatch.get_time(pool)
+
+    def pool_is_stale(self, pool: PoolT) -> bool:
+        return pool in self._stale_pool_set
+
+    def get_last_check_result(self, pool: PoolT) -> StalenessCheckResult | None:
+        return self._last_check_result.get(pool)
 
     # --- Driver operations ---
 
@@ -262,18 +288,72 @@ class PoolState(Generic[PoolT, ConnT]):
         if is_master:
             await self._add_pool_to_master_set(pool, dsn)
             self._remove_pool_from_replica_set(pool, dsn)
+            self._stale_pool_set.discard(pool)
+            self._last_check_result.pop(pool, None)
+            if self._staleness:
+                self._staleness.remove_pool(pool)
         else:
             await self._add_pool_to_replica_set(pool, dsn)
             self._remove_pool_from_master_set(pool, dsn)
+            self._stale_pool_set.discard(pool)
         self._dsn_ready_event[dsn].set()
+
+    # --- Staleness checking ---
+
+    def _make_check_context(self, connection: ConnT) -> CheckContext:
+        return CheckContext(connection, self._driver)
+
+    async def check_replica_staleness(
+        self, pool: PoolT, dsn: Dsn, connection: ConnT,
+    ):
+        if not self._staleness:
+            return
+        if (
+            pool not in self._replica_pool_set
+            and pool not in self._stale_pool_set
+        ):
+            return
+        ctx = self._make_check_context(connection)
+        result = await self._staleness.check(pool, ctx)
+        self._last_check_result[pool] = result
+        if result.is_stale:
+            self._replica_pool_set.discard(pool)
+            self._stale_pool_set.add(pool)
+            logger.info(
+                "Pool %s marked as stale",
+                dsn.with_(password="******"),
+            )
+        else:
+            self._stale_pool_set.discard(pool)
+            if pool not in self._replica_pool_set:
+                await self._add_pool_to_replica_set(pool, dsn)
+                logger.info(
+                    "Pool %s recovered from stale",
+                    dsn.with_(password="******"),
+                )
+
+    async def collect_master_state(self, connection: ConnT):
+        if self._staleness:
+            ctx = self._make_check_context(connection)
+            await self._staleness.collect_master_state(ctx)
+
+    def mark_pool_stale(self, pool: PoolT) -> None:
+        self._replica_pool_set.discard(pool)
+        self._stale_pool_set.add(pool)
 
     def remove_pool_from_all_sets(self, pool: PoolT, dsn: Dsn):
         self._remove_pool_from_master_set(pool, dsn)
         self._remove_pool_from_replica_set(pool, dsn)
+        self._stale_pool_set.discard(pool)
+        self._last_check_result.pop(pool, None)
+        if self._staleness:
+            self._staleness.remove_pool(pool)
 
     def clear_sets(self):
         self._master_pool_set.clear()
         self._replica_pool_set.clear()
+        self._stale_pool_set.clear()
+        self._last_check_result.clear()
 
     # --- Pool registry ---
 
@@ -330,6 +410,7 @@ class PoolState(Generic[PoolT, ConnT]):
         return chain(
             iter(self._master_pool_set),
             iter(self._replica_pool_set),
+            iter(self._stale_pool_set),
         )
 
 

--- a/hasql/staleness.py
+++ b/hasql/staleness.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import re
+import time
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Any
+
+_WAL_LSN_PATTERN = re.compile(r"^[0-9A-Fa-f]+/[0-9A-Fa-f]+$")
+
+
+@dataclass(frozen=True, slots=True)
+class StalenessCheckResult:
+    is_stale: bool
+    lag: dict[str, Any]
+
+
+class CheckContext:
+    """Pre-bound query context for staleness checks.
+    Created by PoolState with the current connection and driver.
+    """
+    __slots__ = ("_connection", "_driver")
+
+    def __init__(self, connection: Any, driver: Any) -> None:
+        self._connection = connection
+        self._driver = driver
+
+    async def fetch_scalar(self, query: str) -> Any:
+        return await self._driver.fetch_scalar(self._connection, query)
+
+
+class BaseStalenessChecker(ABC):
+    async def collect_master_state(self, ctx: CheckContext) -> None:
+        pass
+
+    @abstractmethod
+    async def check(self, ctx: CheckContext) -> StalenessCheckResult: ...
+
+
+class BytesStalenessChecker(BaseStalenessChecker):
+    def __init__(
+        self,
+        max_lag_bytes: int,
+        max_master_lsn_age: timedelta = timedelta(seconds=2),
+    ) -> None:
+        self._max_lag_bytes = max_lag_bytes
+        self._max_master_lsn_age = max_master_lsn_age
+        self._master_lsn: str | None = None
+        self._master_lsn_updated_at: float | None = None
+
+    async def collect_master_state(self, ctx: CheckContext) -> None:
+        self._master_lsn = await ctx.fetch_scalar(
+            "SELECT pg_current_wal_lsn()",
+        )
+        self._master_lsn_updated_at = time.monotonic()
+
+    async def check(self, ctx: CheckContext) -> StalenessCheckResult:
+        if self._master_lsn is None or self._master_lsn_updated_at is None:
+            return StalenessCheckResult(is_stale=False, lag={})
+
+        if not _WAL_LSN_PATTERN.match(self._master_lsn):
+            return StalenessCheckResult(is_stale=True, lag={})
+
+        age = time.monotonic() - self._master_lsn_updated_at
+        if age > self._max_master_lsn_age.total_seconds():
+            return StalenessCheckResult(is_stale=False, lag={})
+
+        lag_bytes = await ctx.fetch_scalar(
+            f"SELECT pg_wal_lsn_diff('{self._master_lsn}'::pg_lsn,"
+            f" pg_last_wal_replay_lsn())::bigint",
+        )
+        if lag_bytes is None:
+            return StalenessCheckResult(is_stale=True, lag={})
+        return StalenessCheckResult(
+            is_stale=lag_bytes > self._max_lag_bytes,
+            lag={"bytes": lag_bytes},
+        )
+
+
+class TimeStalenessChecker(BaseStalenessChecker):
+    def __init__(self, max_lag: timedelta) -> None:
+        self._max_lag = max_lag
+
+    async def check(self, ctx: CheckContext) -> StalenessCheckResult:
+        lag = await ctx.fetch_scalar(
+            "SELECT clock_timestamp() - pg_last_xact_replay_timestamp()",
+        )
+        if lag is None:
+            return StalenessCheckResult(is_stale=True, lag={})
+        return StalenessCheckResult(
+            is_stale=lag > self._max_lag,
+            lag={"time": lag},
+        )
+
+
+class StalenessPolicy:
+    """User-facing configuration for staleness detection.
+    Non-generic — pool identity is opaque (used only as dict keys).
+    """
+
+    def __init__(
+        self,
+        checker: BaseStalenessChecker,
+        grace_period: timedelta | None = None,
+    ) -> None:
+        self._checker = checker
+        self._grace_period = grace_period
+        self._last_fresh_at: dict[Any, float] = {}
+
+    async def check(
+        self,
+        pool: Any,
+        ctx: CheckContext,
+    ) -> StalenessCheckResult:
+        result = await self._checker.check(ctx)
+        if not result.is_stale:
+            self._last_fresh_at[pool] = time.monotonic()
+            return result
+        if self._grace_period is not None and pool in self._last_fresh_at:
+            age = time.monotonic() - self._last_fresh_at[pool]
+            if age < self._grace_period.total_seconds():
+                return StalenessCheckResult(is_stale=False, lag=result.lag)
+        return result
+
+    async def collect_master_state(self, ctx: CheckContext) -> None:
+        await self._checker.collect_master_state(ctx)
+
+    def remove_pool(self, pool: Any) -> None:
+        self._last_fresh_at.pop(pool, None)
+
+
+__all__ = (
+    "StalenessCheckResult",
+    "CheckContext",
+    "BaseStalenessChecker",
+    "TimeStalenessChecker",
+    "BytesStalenessChecker",
+    "StalenessPolicy",
+)

--- a/tests/test_balancer_policy.py
+++ b/tests/test_balancer_policy.py
@@ -329,7 +329,8 @@ async def test_master_as_replica_weight_nonzero_with_no_replicas(
     _get_candidates has a guard: the choose_master_as_replica branch that
     adds masters directly is skipped when replica_pool_count == 0.
     Masters must still be reachable via get_replica_pools(fallback_master=True),
-    which is activated because get_pool() sets fallback_master=choose_master_as_replica.
+    which is activated because get_pool() sets
+    fallback_master=choose_master_as_replica.
     """
     pool_manager = await make_pool_manager(balancer_policy, replicas_count=0)
     async with timeout(1):

--- a/tests/test_staleness.py
+++ b/tests/test_staleness.py
@@ -1,0 +1,337 @@
+import time
+from datetime import timedelta
+from enum import Enum
+
+import pytest
+
+from hasql.metrics import HasqlGauges, PoolMetrics, PoolRole, PoolStaleness
+from hasql.staleness import (
+    BaseStalenessChecker,
+    BytesStalenessChecker,
+    CheckContext,
+    StalenessCheckResult,
+    StalenessPolicy,
+    TimeStalenessChecker,
+)
+
+
+class MockDriver:
+    async def fetch_scalar(self, connection, query):
+        return f"result:{query}"
+
+
+class MockConnection:
+    pass
+
+
+def test_pool_role_values():
+    assert PoolRole.MASTER == "master"
+    assert PoolRole.REPLICA == "replica"
+    assert isinstance(PoolRole.MASTER, str)
+    assert isinstance(PoolRole.MASTER, Enum)
+
+
+def test_pool_staleness_values():
+    assert PoolStaleness.FRESH == "fresh"
+    assert PoolStaleness.STALE == "stale"
+    assert isinstance(PoolStaleness.FRESH, str)
+    assert isinstance(PoolStaleness.FRESH, Enum)
+
+
+def test_pool_metrics_with_staleness_fields():
+    pm = PoolMetrics(
+        host="localhost",
+        role=PoolRole.REPLICA,
+        healthy=True,
+        min=1,
+        max=10,
+        idle=5,
+        used=4,
+        response_time=0.01,
+        in_flight=1,
+        staleness=PoolStaleness.FRESH,
+        lag={"time": 1.5},
+    )
+    assert pm.staleness == PoolStaleness.FRESH
+    assert pm.lag == {"time": 1.5}
+
+
+def test_pool_metrics_staleness_none_for_master():
+    pm = PoolMetrics(
+        host="localhost",
+        role=PoolRole.MASTER,
+        healthy=True,
+        min=1,
+        max=10,
+        idle=5,
+        used=4,
+        response_time=0.01,
+        in_flight=0,
+        staleness=None,
+        lag={},
+    )
+    assert pm.staleness is None
+    assert pm.lag == {}
+
+
+def test_hasql_gauges_with_stale_and_unavailable():
+    g = HasqlGauges(
+        master_count=1,
+        replica_count=2,
+        available_count=4,
+        active_connections=3,
+        closing=False,
+        closed=False,
+        stale_count=1,
+        unavailable_count=0,
+    )
+    assert g.stale_count == 1
+    assert g.unavailable_count == 0
+
+
+def test_staleness_check_result_creation():
+    result = StalenessCheckResult(is_stale=True, lag={"time": 5.0})
+    assert result.is_stale is True
+    assert result.lag == {"time": 5.0}
+
+
+def test_staleness_check_result_is_frozen():
+    result = StalenessCheckResult(is_stale=False, lag={})
+    with pytest.raises(AttributeError):
+        result.is_stale = True  # type: ignore[misc]
+
+
+@pytest.mark.asyncio
+async def test_check_context_fetch_scalar():
+    driver = MockDriver()
+    conn = MockConnection()
+    ctx = CheckContext(connection=conn, driver=driver)
+    result = await ctx.fetch_scalar("SELECT 1")
+    assert result == "result:SELECT 1"
+
+
+@pytest.mark.asyncio
+async def test_base_staleness_checker_collect_master_state_is_noop():
+    """Default collect_master_state does nothing."""
+    class NoopChecker(BaseStalenessChecker):
+        async def check(self, ctx):
+            return StalenessCheckResult(is_stale=False, lag={})
+
+    checker = NoopChecker()
+    ctx = CheckContext(connection=MockConnection(), driver=MockDriver())
+    # Should not raise
+    await checker.collect_master_state(ctx)
+
+
+class TimeMockDriver:
+    def __init__(self, lag_interval):
+        self._lag_interval = lag_interval
+
+    async def fetch_scalar(self, connection, query):
+        return self._lag_interval
+
+
+@pytest.mark.asyncio
+async def test_time_staleness_checker_fresh():
+    driver = TimeMockDriver(lag_interval=timedelta(seconds=5))
+    ctx = CheckContext(connection=MockConnection(), driver=driver)
+    checker = TimeStalenessChecker(max_lag=timedelta(seconds=10))
+    result = await checker.check(ctx)
+    assert result.is_stale is False
+    assert result.lag == {"time": timedelta(seconds=5)}
+
+
+@pytest.mark.asyncio
+async def test_time_staleness_checker_stale():
+    driver = TimeMockDriver(lag_interval=timedelta(seconds=15))
+    ctx = CheckContext(connection=MockConnection(), driver=driver)
+    checker = TimeStalenessChecker(max_lag=timedelta(seconds=10))
+    result = await checker.check(ctx)
+    assert result.is_stale is True
+    assert result.lag == {"time": timedelta(seconds=15)}
+
+
+@pytest.mark.asyncio
+async def test_time_staleness_checker_null_replay_timestamp():
+    driver = TimeMockDriver(lag_interval=None)
+    ctx = CheckContext(connection=MockConnection(), driver=driver)
+    checker = TimeStalenessChecker(max_lag=timedelta(seconds=10))
+    result = await checker.check(ctx)
+    assert result.is_stale is True
+    assert result.lag == {}
+
+
+@pytest.mark.asyncio
+async def test_time_staleness_checker_exact_threshold():
+    driver = TimeMockDriver(lag_interval=timedelta(seconds=10))
+    ctx = CheckContext(connection=MockConnection(), driver=driver)
+    checker = TimeStalenessChecker(max_lag=timedelta(seconds=10))
+    result = await checker.check(ctx)
+    assert result.is_stale is False
+
+
+class BytesMockDriver:
+    def __init__(self, lag_bytes=None, master_lsn=None):
+        self._lag_bytes = lag_bytes
+        self._master_lsn = master_lsn
+
+    async def fetch_scalar(self, connection, query):
+        if "pg_current_wal_lsn" in query:
+            return self._master_lsn
+        if "pg_wal_lsn_diff" in query:
+            return self._lag_bytes
+        return None
+
+
+@pytest.mark.asyncio
+async def test_bytes_staleness_checker_fresh():
+    driver = BytesMockDriver(lag_bytes=1000)
+    master_driver = BytesMockDriver(master_lsn="0/1000000")
+    ctx_master = CheckContext(
+        connection=MockConnection(), driver=master_driver,
+    )
+    ctx_replica = CheckContext(connection=MockConnection(), driver=driver)
+
+    checker = BytesStalenessChecker(max_lag_bytes=1024 * 1024)
+    await checker.collect_master_state(ctx_master)
+    result = await checker.check(ctx_replica)
+    assert result.is_stale is False
+    assert result.lag == {"bytes": 1000}
+
+
+@pytest.mark.asyncio
+async def test_bytes_staleness_checker_stale():
+    driver = BytesMockDriver(lag_bytes=2 * 1024 * 1024)
+    master_driver = BytesMockDriver(master_lsn="0/2000000")
+    ctx_master = CheckContext(
+        connection=MockConnection(), driver=master_driver,
+    )
+    ctx_replica = CheckContext(connection=MockConnection(), driver=driver)
+
+    checker = BytesStalenessChecker(max_lag_bytes=1024 * 1024)
+    await checker.collect_master_state(ctx_master)
+    result = await checker.check(ctx_replica)
+    assert result.is_stale is True
+    assert result.lag == {"bytes": 2 * 1024 * 1024}
+
+
+@pytest.mark.asyncio
+async def test_bytes_staleness_checker_no_master_lsn():
+    driver = BytesMockDriver(lag_bytes=999)
+    ctx = CheckContext(connection=MockConnection(), driver=driver)
+
+    checker = BytesStalenessChecker(max_lag_bytes=100)
+    result = await checker.check(ctx)
+    assert result.is_stale is False
+    assert result.lag == {}
+
+
+@pytest.mark.asyncio
+async def test_bytes_staleness_checker_stale_master_lsn():
+    """If cached master LSN is too old, assume fresh."""
+    driver = BytesMockDriver(lag_bytes=2 * 1024 * 1024)
+    master_driver = BytesMockDriver(master_lsn="0/3000000")
+    ctx_master = CheckContext(
+        connection=MockConnection(), driver=master_driver,
+    )
+    ctx_replica = CheckContext(connection=MockConnection(), driver=driver)
+
+    checker = BytesStalenessChecker(
+        max_lag_bytes=1024 * 1024,
+        max_master_lsn_age=timedelta(seconds=2),
+    )
+    await checker.collect_master_state(ctx_master)
+
+    # Simulate time passing beyond max_master_lsn_age
+    checker._master_lsn_updated_at -= 3.0
+
+    result = await checker.check(ctx_replica)
+    assert result.is_stale is False
+    assert result.lag == {}
+
+
+class AlwaysFreshChecker(BaseStalenessChecker):
+    async def check(self, ctx):
+        return StalenessCheckResult(
+            is_stale=False, lag={"time": timedelta(seconds=1)},
+        )
+
+
+class AlwaysStaleChecker(BaseStalenessChecker):
+    async def check(self, ctx):
+        return StalenessCheckResult(
+            is_stale=True, lag={"time": timedelta(seconds=20)},
+        )
+
+
+@pytest.mark.asyncio
+async def test_staleness_policy_fresh():
+    policy = StalenessPolicy(checker=AlwaysFreshChecker())
+    ctx = CheckContext(connection=MockConnection(), driver=MockDriver())
+    result = await policy.check(pool="pool1", ctx=ctx)
+    assert result.is_stale is False
+
+
+@pytest.mark.asyncio
+async def test_staleness_policy_stale():
+    policy = StalenessPolicy(checker=AlwaysStaleChecker())
+    ctx = CheckContext(connection=MockConnection(), driver=MockDriver())
+    result = await policy.check(pool="pool1", ctx=ctx)
+    assert result.is_stale is True
+
+
+@pytest.mark.asyncio
+async def test_staleness_policy_grace_period():
+    """Pool stays fresh during grace period even when checker says stale."""
+    policy = StalenessPolicy(
+        checker=AlwaysFreshChecker(),
+        grace_period=timedelta(seconds=30),
+    )
+    ctx = CheckContext(connection=MockConnection(), driver=MockDriver())
+
+    # First check: fresh — records last_fresh_at
+    result = await policy.check(pool="pool1", ctx=ctx)
+    assert result.is_stale is False
+
+    # Switch to stale checker
+    policy._checker = AlwaysStaleChecker()
+
+    # Second check: checker says stale but within grace period
+    result = await policy.check(pool="pool1", ctx=ctx)
+    assert result.is_stale is False
+    assert result.lag == {"time": timedelta(seconds=20)}
+
+
+@pytest.mark.asyncio
+async def test_staleness_policy_grace_period_expired():
+    """Pool becomes stale after grace period expires."""
+    policy = StalenessPolicy(
+        checker=AlwaysStaleChecker(),
+        grace_period=timedelta(seconds=1),
+    )
+    ctx = CheckContext(connection=MockConnection(), driver=MockDriver())
+
+    # Manually set last_fresh_at in the past
+    policy._last_fresh_at["pool1"] = time.monotonic() - 2.0
+
+    result = await policy.check(pool="pool1", ctx=ctx)
+    assert result.is_stale is True
+
+
+@pytest.mark.asyncio
+async def test_staleness_policy_remove_pool():
+    policy = StalenessPolicy(checker=AlwaysFreshChecker())
+    ctx = CheckContext(connection=MockConnection(), driver=MockDriver())
+
+    await policy.check(pool="pool1", ctx=ctx)
+    assert "pool1" in policy._last_fresh_at
+
+    policy.remove_pool("pool1")
+    assert "pool1" not in policy._last_fresh_at
+
+
+@pytest.mark.asyncio
+async def test_staleness_policy_remove_pool_not_tracked():
+    policy = StalenessPolicy(checker=AlwaysFreshChecker())
+    # Should not raise
+    policy.remove_pool("nonexistent")

--- a/tests/test_staleness_integration.py
+++ b/tests/test_staleness_integration.py
@@ -1,0 +1,93 @@
+import pytest
+
+from tests.mocks.pool_manager import TestPoolManager
+
+
+@pytest.fixture
+def make_dsn():
+    def factory(replicas=2):
+        hosts = ",".join(
+            ["master"] + [f"replica{i}" for i in range(replicas)],
+        )
+        return f"postgresql://test:test@{hosts}:5432/test"
+    return factory
+
+
+@pytest.fixture
+async def pool_manager(make_dsn):
+    pm = TestPoolManager(make_dsn(replicas=2))
+    await pm.ready(masters_count=1, replicas_count=2)
+    yield pm
+    await pm.close()
+
+
+async def test_pool_state_stale_pool_set_empty_by_default(pool_manager):
+    ps = pool_manager._pool_state
+    assert ps.stale_pool_count == 0
+    assert ps.get_stale_pools() == []
+
+
+async def test_pool_state_stale_pools_in_iter(pool_manager):
+    ps = pool_manager._pool_state
+    all_pools = list(ps)
+    # master + 2 replicas, no stale
+    assert len(all_pools) == 3
+
+
+async def test_pool_state_available_pool_count_includes_stale(pool_manager):
+    ps = pool_manager._pool_state
+    # Move one replica to stale set
+    replica_pools = list(ps._replica_pool_set)
+    stale_pool = replica_pools[0]
+    ps._replica_pool_set.discard(stale_pool)
+    ps._stale_pool_set.add(stale_pool)
+
+    assert ps.stale_pool_count == 1
+    assert ps.replica_pool_count == 1
+    assert ps.available_pool_count == 3  # 1 master + 1 replica + 1 stale
+
+
+async def test_balancer_prefers_fresh_over_stale():
+    """When fresh replicas exist, stale replicas are not selected."""
+    dsn = "postgresql://test:test@master,replica0,replica1:5432/test"
+    pm = TestPoolManager(dsn)
+    await pm.ready(masters_count=1, replicas_count=2)
+
+    ps = pm._pool_state
+    # Move one replica to stale set manually
+    replica_pools = list(ps._replica_pool_set)
+    stale_pool = replica_pools[0]
+    fresh_pool = replica_pools[1]
+    ps._replica_pool_set.discard(stale_pool)
+    ps._stale_pool_set.add(stale_pool)
+
+    # Acquire should get the fresh pool
+    async with pm.acquire_replica() as conn:
+        assert conn._pool is fresh_pool
+
+    await pm.close()
+
+
+async def test_balancer_falls_back_to_stale():
+    """When no fresh replicas or masters, falls back to stale."""
+    dsn = "postgresql://test:test@master,replica0:5432/test"
+    pm = TestPoolManager(dsn)
+    await pm.ready(masters_count=1, replicas_count=1)
+
+    ps = pm._pool_state
+    # Move all replicas to stale
+    replica_pools = list(ps._replica_pool_set)
+    for pool in replica_pools:
+        ps._replica_pool_set.discard(pool)
+        ps._stale_pool_set.add(pool)
+
+    # Also remove master to test stale-only fallback
+    master_pools = list(ps._master_pool_set)
+    for pool in master_pools:
+        ps._master_pool_set.discard(pool)
+
+    # Should fall back to stale
+    async with pm.acquire_replica() as conn:
+        assert conn._pool in ps._stale_pool_set
+
+    await pm.close()


### PR DESCRIPTION
## Summary
- Add `staleness.py`: `BytesStalenessChecker` (WAL byte lag), `TimeStalenessChecker` (replay timestamp), `StalenessPolicy` with grace period
- Integrate into `PoolState`: stale pool set, automatic stale↔replica transitions
- Add tiered fallback to balancer: fresh replicas → master → stale replicas → wait
- Extend metrics: `PoolStaleness` enum, `staleness`/`lag` fields, `stale_count` gauge

## Stack
MR 2/3 — staleness detection (target: mr/1-core-refactoring)

## Test plan
- [x] `ruff check` passes
- [x] `mypy` — no issues in 47 source files
- [x] `pytest` — 211 unit tests pass (28 new staleness tests)