### PR TITLE
build: switch to setuptools-scm versioning and add PyPI publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4
@@ -25,5 +27,3 @@ jobs:
 
       - name: Publish to PyPI
         run: uv publish
-        env:
-          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,29 @@
+name: Publish to PyPI
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Build package
+        run: uv build
+
+      - name: Publish to PyPI
+        run: uv publish
+        env:
+          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}

--- a/hasql/__init__.py
+++ b/hasql/__init__.py
@@ -1,5 +1,4 @@
-__version_info__ = (0, 9, 0)
-__version__ = ".".join(map(str, __version_info__))
+from hasql.version import __version__
 
 package_info = (
     "hasql is a module for acquiring actual connections with masters "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ Documentation = "https://github.com/aiokitchen/hasql/blob/master/README.rst"
 version = { attr = "hasql.version.__version__" }
 
 [tool.setuptools.packages.find]
-exclude = ["tests*", "example*"]
+include = ["hasql*"]
 
 [tool.setuptools.package-data]
 hasql = ["py.typed"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=69", "wheel"]
+requires = ["setuptools>=69", "wheel", "setuptools_scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -80,7 +80,7 @@ Tracker = "https://github.com/aiokitchen/hasql/issues"
 Documentation = "https://github.com/aiokitchen/hasql/blob/master/README.rst"
 
 [tool.setuptools.dynamic]
-version = { attr = "hasql.__version__" }
+version = { attr = "hasql.version.__version__" }
 
 [tool.setuptools.packages.find]
 exclude = ["tests*", "example*"]

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,23 @@
+from setuptools import setup
+
+
+def version_scheme(version):
+    """Custom version: MAJOR.MINOR.COMMITS_SINCE_TAG"""
+    if version.exact:
+        return f"{version.tag}.0"
+    return f"{version.tag}.{version.distance}"
+
+
+def local_scheme(version):
+    """No local version component."""
+    return ""
+
+
+setup(
+    use_scm_version={
+        "version_scheme": version_scheme,
+        "local_scheme": local_scheme,
+        "tag_regex": r"^v(?P<version>\d+\.\d+)$",
+        "write_to": "hasql/version.py",
+    }
+)


### PR DESCRIPTION
## Summary

- Replace manual `__version_info__` tuple with `setuptools-scm` (version derived from git tags)
- Add `setup.py` with custom `MAJOR.MINOR.COMMITS_SINCE_TAG` scheme (same as aiomisc)
- Add `.github/workflows/publish.yml` — publishes to PyPI on every push to master via `uv publish`
- Tag `v0.9` set as baseline on commit `19110ac`

## How versioning works

Tag `v0.9` → first build is `0.9.0`, each subsequent commit increments the patch: `0.9.1`, `0.9.2`, etc.
To bump minor/major — create a new tag (`v0.10`, `v1.0`).

## Required setup

Add `PYPI_TOKEN` secret in repository Settings → Secrets → Actions.