### PR TITLE
ci: add environment pypi to match trusted publisher config

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: pypi
     permissions:
       id-token: write
 


### PR DESCRIPTION
PyPI Trusted Publisher configured with `Environment name: pypi`, workflow was missing `environment: pypi` — causing claims mismatch and 422 on publish.